### PR TITLE
removing vmSize variable from.sh, removing passing paramater to .sh

### DIFF
--- a/Vms/extralarge.json
+++ b/Vms/extralarge.json
@@ -515,7 +515,7 @@
                       "fileUris": [
 			    "[concat(variables('baseUri'),'scripts/extraLarge.sh')]"			    
                       ],
-                        "commandToExecute": "[concat('sh extraLarge.sh \"', parameters('customUri'), '\" \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"', parameters('vmSize'), '\" \"', parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\" \"', parameters('SMTUri'),'\"')]"
+                        "commandToExecute": "[concat('sh extraLarge.sh \"', parameters('customUri'), '\" \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"', parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\" \"', parameters('SMTUri'),'\"')]"
                         
                     }
                 }

--- a/Vms/large.json
+++ b/Vms/large.json
@@ -466,7 +466,7 @@
                       "fileUris": [
 			    "[concat(variables('baseUri'),'scripts/large.sh')]"			    
                       ],
-                        "commandToExecute": "[concat('sh large.sh \"', parameters('customUri'), '\" \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"', parameters('vmSize'), '\" \"', parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\"  \"', parameters('SMTUri'),'\"')]"
+                        "commandToExecute": "[concat('sh large.sh \"', parameters('customUri'), '\" \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"', parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\"  \"', parameters('SMTUri'),'\"')]"
                     }
                 }
             }]

--- a/Vms/medium.json
+++ b/Vms/medium.json
@@ -433,7 +433,7 @@
 			"fileUris": [
 			    "[concat(variables('baseUri'),'scripts/medium.sh')]"			    
                       ],
-                        "commandToExecute": "[concat('sh medium.sh \"', parameters('customUri'), '\" \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"', parameters('vmSize'), '\" \"', parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\"  \"', parameters('SMTUri'),'\"')]"
+                        "commandToExecute": "[concat('sh medium.sh \"', parameters('customUri'), '\" \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"', parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\"  \"', parameters('SMTUri'),'\"')]"
                     }
                 }
             }]

--- a/Vms/small.json
+++ b/Vms/small.json
@@ -368,7 +368,7 @@
                 "fileUris": [
                   "[concat(variables('baseUri'),'scripts/small.sh')]"
                 ],
-                "commandToExecute": "[concat('sh small.sh \"', parameters('customUri'), '\"  \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"', parameters('vmSize'), '\" \"',parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\"  \"', parameters('SMTUri'),'\"')]"
+                "commandToExecute": "[concat('sh small.sh \"', parameters('customUri'), '\"  \"' , parameters('vmUserName'), '\" \"', parameters('vmPassword'),'\" \"', parameters('HANASID'), '\" \"', parameters('HANANUMBER'), '\" \"',parameters('SubscriptionEmail'), '\" \"', parameters('SubscriptionID'),'\"  \"', parameters('SMTUri'),'\"')]"
               }
             }
           }

--- a/scripts/extraLarge.sh
+++ b/scripts/extraLarge.sh
@@ -3,10 +3,9 @@ HANAUSR=$2
 HANAPWD=$3
 HANASID=$4
 HANANUMBER=$5
-vmSize=$6
-SUBEMAIL=$7
-SUBID=$8
-SUBURL=$9
+SUBEMAIL=$6
+SUBID=$7
+SUBURL=$8
 
 #if needed, register the machine
 if [ "$SUBEMAIL" != "" ]; then

--- a/scripts/large.sh
+++ b/scripts/large.sh
@@ -3,10 +3,9 @@ HANAUSR=$2
 HANAPWD=$3
 HANASID=$4
 HANANUMBER=$5
-vmSize=$6
-SUBEMAIL=$7
-SUBID=$8
-SUBURL=$9
+SUBEMAIL=$6
+SUBID=$7
+SUBURL=$8
 
 #if needed, register the machine
 if [ "$SUBEMAIL" != "" ]; then

--- a/scripts/medium.sh
+++ b/scripts/medium.sh
@@ -3,10 +3,9 @@ HANAUSR=$2
 HANAPWD=$3
 HANASID=$4
 HANANUMBER=$5
-vmSize=$6
-SUBEMAIL=$7
-SUBID=$8
-SUBURL=$9
+SUBEMAIL=$6
+SUBID=$7
+SUBURL=$8
 
 #if needed, register the machine
 if [ "$SUBEMAIL" != "" ]; then

--- a/scripts/small.sh
+++ b/scripts/small.sh
@@ -3,10 +3,9 @@ HANAUSR=$2
 HANAPWD=$3
 HANASID=$4
 HANANUMBER=$5
-vmSize=$6
-SUBEMAIL=$7
-SUBID=$8
-SUBURL=$9
+SUBEMAIL=$6
+SUBID=$7
+SUBURL=$8
 
 #if needed, register the machine
 if [ "$SUBEMAIL" != "" ]; then


### PR DESCRIPTION
## What

This is to fix issues #29 
I removed the vmSize variable from the .sh files
I renumbered the variables in the .sh files.
I removed the parameter vmSize in the call from the .json files to the .sh files


* https://app.asana.com/0/215934242492110/215134730711638
* https://github.com/example/repo/pulls/232

## TODO
- [x] something that was recently finished
- [ ] something you are working on
- [ ] something else you are working on